### PR TITLE
Update to dedicated link for API in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,7 +15,7 @@ var config = {
 
 app.use(requestTime);
 
-app.get('/', function (req, res) {
+app.get('/api', function (req, res) {
     const pair = req.query.pair || 'xbtusd';
   axios.get(`https://api.kraken.com/0/public/Depth?pair=${pair}&count=4`, config).then((response) => {
     const pair = Object.keys(response.data.result)[0];


### PR DESCRIPTION
app.get('/api', function (req, res) {
should be better, to split www and rest call